### PR TITLE
Make kid unique only in combination with public use

### DIFF
--- a/src/Key/AbstractKey.php
+++ b/src/Key/AbstractKey.php
@@ -66,7 +66,7 @@ abstract class AbstractKey implements KeyInterface
      *
      * @since 1.0.0
      */
-    public function getKeyId(): string
+    public function getKeyId(): ?string
     {
         return $this->kid;
     }
@@ -76,7 +76,7 @@ abstract class AbstractKey implements KeyInterface
      *
      * @since 1.0.0
      */
-    public function getPublicKeyUse(): string
+    public function getPublicKeyUse(): ?string
     {
         return $this->use;
     }

--- a/src/Key/KeyInterface.php
+++ b/src/Key/KeyInterface.php
@@ -52,7 +52,7 @@ interface KeyInterface extends \JsonSerializable
      *
      * @since 1.0.0
      */
-    public function getPublicKeyUse(): string;
+    public function getPublicKeyUse(): ?string;
 
     /**
      * Gets the cryptographic algorithm used to sign the key, ie. the value of the `alg` field.

--- a/src/KeySet.php
+++ b/src/KeySet.php
@@ -59,7 +59,7 @@ class KeySet implements \JsonSerializable
      */
     public function containsKey(string $kid, string $use = KeyInterface::PUBLIC_KEY_USE_SIGNATURE): bool
     {
-        return $this->getKeyById($kid, $use) !== null;
+        return null !== $this->getKeyById($kid, $use);
     }
 
     /**
@@ -69,7 +69,7 @@ class KeySet implements \JsonSerializable
     public function getKeyById(string $kid, string $use = KeyInterface::PUBLIC_KEY_USE_SIGNATURE): ?KeyInterface
     {
         foreach ($this->getKeys() as $key) {
-            if ($key->getKeyId() == $kid && $key->getPublicKeyUse() == $use) {
+            if ($key->getKeyId() === $kid && $key->getPublicKeyUse() === $use) {
                 return $key;
             }
         }
@@ -98,7 +98,7 @@ class KeySet implements \JsonSerializable
      */
     public function getKeys(): array
     {
-        return array_values($this->keys);
+        return \array_values($this->keys);
     }
 
     /**

--- a/src/KeySet.php
+++ b/src/KeySet.php
@@ -54,23 +54,27 @@ class KeySet implements \JsonSerializable
     }
 
     /**
-     * @since 1.0.0
+     * @since 1.0.0 Only $kid parameter
+     * @since 1.1.0 Added optional $use parameter
      */
-    public function containsKey(string $kid): bool
+    public function containsKey(string $kid, string $use = KeyInterface::PUBLIC_KEY_USE_SIGNATURE): bool
     {
-        return \array_key_exists($kid, $this->keys);
+        return $this->getKeyById($kid, $use) !== null;
     }
 
     /**
      * @since 1.0.0
+     * @since 1.1.0 Added optional $use parameter
      */
-    public function getKeyById(string $kid): ?KeyInterface
+    public function getKeyById(string $kid, string $use = KeyInterface::PUBLIC_KEY_USE_SIGNATURE): ?KeyInterface
     {
-        if (!$this->containsKey($kid)) {
-            return null;
+        foreach ($this->getKeys() as $key) {
+            if ($key->getKeyId() == $kid && $key->getPublicKeyUse() == $use) {
+                return $key;
+            }
         }
 
-        return $this->keys[$kid];
+        return null;
     }
 
     /**
@@ -80,13 +84,21 @@ class KeySet implements \JsonSerializable
      */
     public function addKey(KeyInterface $key): self
     {
-        if ($this->containsKey($key->getKeyId())) {
-            throw new \InvalidArgumentException(\sprintf('Key with id `%s` already exists in the set', $key->getKeyId()));
+        if ($this->containsKey($key->getKeyId(), $key->getPublicKeyUse())) {
+            throw new \InvalidArgumentException(\sprintf('Key with id `%s` and use `%s` already exists in the set', $key->getKeyId(), $key->getPublicKeyUse()));
         }
 
-        $this->keys[$key->getKeyId()] = $key;
+        $this->keys[] = $key;
 
         return $this;
+    }
+
+    /**
+     * @return KeyInterface[]
+     */
+    public function getKeys(): array
+    {
+        return array_values($this->keys);
     }
 
     /**
@@ -96,7 +108,7 @@ class KeySet implements \JsonSerializable
     {
         $ret = [];
 
-        foreach ($this->keys as $key) {
+        foreach ($this->getKeys() as $key) {
             $ret[$key->getKeyId()] = $key->jsonSerialize();
         }
 


### PR DESCRIPTION
This PR makes the kid only unique in combination of public use field in KeySet.

Also kid isn't a mandatory field in KeySet any more.