### PR TITLE
Fixes an issue where invalid JSON produces a warning in the foreach of the keyset factory.

### DIFF
--- a/src/KeySetFactory.php
+++ b/src/KeySetFactory.php
@@ -45,6 +45,10 @@ class KeySetFactory
 
         $instance = new KeySet();
 
+        if (! is_array($assoc) || ! array_key_exists('keys', $assoc)) {
+            return $instance;
+        }
+
         foreach ($assoc['keys'] as $keyData) {
             $key = $this->keyFactory->createFromJson(\json_encode($keyData));
 

--- a/tests/KeySetFactoryTest.php
+++ b/tests/KeySetFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Strobotti\JWK\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Strobotti\JWK\KeySet;
 use Strobotti\JWK\KeySetFactory;
 
 /**
@@ -23,6 +24,17 @@ final class KeySetFactoryTest extends TestCase
         $json = $keys->jsonSerialize();
 
         static::assertSame(\json_decode($input, true), $json);
+    }
+
+    public function testInvalidJsonReturnsEmptyKeySet(): void
+    {
+        $invalidJson = '{}';
+
+        $factory = new KeySetFactory();
+
+        $keySet = $factory->createFromJSON($invalidJson);
+        $this->assertInstanceOf(KeySet::class, $keySet);
+        $this->assertCount(0, $keySet);
     }
 
     public function provideCreateFromJSON(): \Generator


### PR DESCRIPTION
This PR checks that the JSON is valid (and a valid array is created) and returns an empty keyset if the JSON is somehow invalid.

It also adds a test for the same.