### PR TITLE
fix: php 8.4 compatibility

### DIFF
--- a/src/Key/AbstractKey.php
+++ b/src/Key/AbstractKey.php
@@ -165,7 +165,7 @@ abstract class AbstractKey implements KeyInterface
     /**
      * @since 1.0.0
      */
-    public static function createFromJSON(string $json, KeyInterface $prototype = null): KeyInterface
+    public static function createFromJSON(string $json, ?KeyInterface $prototype = null): KeyInterface
     {
         $assoc = \json_decode($json, true);
 

--- a/src/Key/Rsa.php
+++ b/src/Key/Rsa.php
@@ -100,7 +100,7 @@ class Rsa extends AbstractKey
      *
      * @return self
      */
-    public static function createFromJSON(string $json, KeyInterface $prototype = null): KeyInterface
+    public static function createFromJSON(string $json, ?KeyInterface $prototype = null): KeyInterface
     {
         if (!$prototype instanceof self) {
             $prototype = new static();


### PR DESCRIPTION
fixed https://github.com/Strobotti/php-jwk/issues/15

This PR fixes the php warning, doesn't add PHP 8.4 to the CI